### PR TITLE
Fix errors under 5.x and allow selecting warps from a dropdown

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,16 @@
+read_globals = {
+	"DIR_DELIM",
+	"core",
+	"dump",
+	"vector", "nodeupdate",
+	"VoxelManip", "VoxelArea",
+	"PseudoRandom", "ItemStack",
+	"AreaStore",
+	"default",
+	table = { fields = { "copy", "getn" } }
+}
+
+globals = {
+	"minetest"
+}
+

--- a/init.lua
+++ b/init.lua
@@ -246,7 +246,7 @@ local function prepare_dropdown(x,y,w,h,curr_dest)
 	local sel = 0
 	for idx, warp in ipairs(warps) do
 		local warpname = warp.name
-		dd = dd .. warpname .. ","
+		dd = dd .. minetest.formspec_escape(warpname) .. ","
 		if curr_dest == warpname then
 			sel = idx
 		end
@@ -263,7 +263,8 @@ local function prepare_formspec(dest)
 		custdest = ""
 	end
 	s_formspec = "size[4.5,3]label[0.7,0;Warp destination]"
-	s_formspec = s_formspec .. "field[1,2.2;3,0.2;destination;Future destination;"..custdest.."]"
+	s_formspec = s_formspec .. "field[1,2.2;3,0.2;destination;Future destination;"
+		..minetest.formspec_escape(custdest).."]"
 		.."button_exit[0.7,2.7;3,0.5;proceed;Proceed]"
 		..prepare_dropdown(0.7,0.4,3,1, dest)
 	return s_formspec
@@ -299,8 +300,6 @@ minetest.register_node("warps:warpstone", {
 			return
 		end
 
-		local ddwarp = fields.ddwarp
-		local is_custom_dest = false
 		local dest
 		if fields.destination == "" and fields.ddwarp then
 			dest = fields.ddwarp
@@ -332,7 +331,9 @@ minetest.register_node("warps:warpstone", {
 					"Unknown warp location for this warp stone, cannot warp!")
 			return false
 		end
-		minetest.log("action", "Going to warp to: "..destination)
+		minetest.log("action", string.format("Going to warp player %s to waypoint %s",
+			puncher:get_player_name(), minetest.formspec_escape(destination)
+		))
 		warp_queue_add(puncher, destination)
 	end,
 })

--- a/init.lua
+++ b/init.lua
@@ -256,17 +256,15 @@ local function prepare_dropdown(x,y,w,h,curr_dest)
 end
 
 local function prepare_formspec(dest)
-	local custdest
+	local custdest = ""
 	if not lookup_warp(dest) then
 		custdest = dest
-	else
-		custdest = ""
 	end
 	return "size[4.5,3]label[0.7,0;Warp destination]"
-	.."field[1,2.2;3,0.2;destination;Future destination;"
-	..minetest.formspec_escape(custdest).."]"
-	.."button_exit[0.7,2.7;3,0.5;proceed;Proceed]"
-	..prepare_dropdown(0.7,0.4,3,1, dest)
+		.."field[1,2.2;3,0.2;destination;Future destination;"
+		..minetest.formspec_escape(custdest).."]"
+		.."button_exit[0.7,2.7;3,0.5;proceed;Proceed]"
+		..prepare_dropdown(0.7,0.4,3,1, dest)
 end
 
 minetest.register_node("warps:warpstone", {

--- a/init.lua
+++ b/init.lua
@@ -95,7 +95,7 @@ local warp = function(player, dest)
 	minetest.sound_play("warps_plop", {pos = pos})
 end
 
-do_warp_queue = function()
+local function do_warp_queue()
 	if table.getn(warps_queue) == 0 then
 		queue_state = 0
 		return
@@ -262,12 +262,11 @@ local function prepare_formspec(dest)
 	else
 		custdest = ""
 	end
-	s_formspec = "size[4.5,3]label[0.7,0;Warp destination]"
-	s_formspec = s_formspec .. "field[1,2.2;3,0.2;destination;Future destination;"
-		..minetest.formspec_escape(custdest).."]"
-		.."button_exit[0.7,2.7;3,0.5;proceed;Proceed]"
-		..prepare_dropdown(0.7,0.4,3,1, dest)
-	return s_formspec
+	return "size[4.5,3]label[0.7,0;Warp destination]"
+	.."field[1,2.2;3,0.2;destination;Future destination;"
+	..minetest.formspec_escape(custdest).."]"
+	.."button_exit[0.7,2.7;3,0.5;proceed;Proceed]"
+	..prepare_dropdown(0.7,0.4,3,1, dest)
 end
 
 minetest.register_node("warps:warpstone", {
@@ -308,7 +307,6 @@ minetest.register_node("warps:warpstone", {
 		end
 
 		local meta = minetest.get_meta(pos)
-		local s_formspec, formspec_help
 
 		meta:set_string("formspec", prepare_formspec(dest))
 		meta:set_string("infotext", "Warp stone to " .. dest)
@@ -332,7 +330,7 @@ minetest.register_node("warps:warpstone", {
 			return false
 		end
 		minetest.log("action", string.format("Going to warp player %s to waypoint %s",
-			puncher:get_player_name(), minetest.formspec_escape(destination)
+			puncher:get_player_name(), destination
 		))
 		warp_queue_add(puncher, destination)
 	end,


### PR DESCRIPTION
- Loading would previously fail if there was both no data in mod_storage "warps" and no warps.txt
- A wrong variable used while adding the warp queue was causing crashes when attempting to warp
- Don't even attempt to teleport to a warp spot that doesn't exit
- Allow selecting warps from a dropdown for ease of use, but still allow text input as warps might be created later than the warp crystals are created (negotiable, invalid input could be dropped and only the combobox allowed if others object).